### PR TITLE
Fixing dead links in TOC and other fixes

### DIFF
--- a/dps-web-experience-sample/Scripts/index.js
+++ b/dps-web-experience-sample/Scripts/index.js
@@ -21,7 +21,7 @@
     "chutzpah": { parent: "debug_and_test" },
 
     "package-app-built-with-visual-studio": { parent: "package_and_publish" }, "tutorial-package-publish-readme": { parent: "package_and_publish" },
-    "tutorial-package-publish-readme": { parent: "package_and_publish" }, "publish-app-built-with-visual-studio": { parent: "package_and_publish" },
+    "get-your-app-approved": { parent: "package_and_publish" }, "publish-app-built-with-visual-studio": { parent: "package_and_publish" },
 
     "tutorial-ionic": { parent: "tutorials_and_samples" }, "O365_Files": { parent: "tutorials_and_samples" }, "O365_Ionic": { parent: "tutorials_and_samples" },
     "convert_cordova_phonegap": { parent: "tutorials_and_samples" },

--- a/dps-web-experience-sample/Views/Shared/_DocsNav.cshtml
+++ b/dps-web-experience-sample/Views/Shared/_DocsNav.cshtml
@@ -124,9 +124,9 @@
 
                 <li id="tutorial-ionic"><a href="~/en-us/docs/tutorial-ionic/">Get started with Ionic</a></li>
 
-                <li id="O365_Files"><a href="~/en-us/docs/O365_Files/">O365 Files API</a></li>
+                <li id="O365_Files"><a href="~/en-us/docs/o365_Files/">O365 Files API</a></li>
 
-                <li id="O365_Ionic"><a href="~/en-us/docs/O365_Ionic/">O365 Outlook and Ionic</a></li>
+                <li id="O365_Ionic"><a href="~/en-us/docs/o365_Ionic/">O365 Outlook and Ionic</a></li>
 
                 <li id="convert_cordova_phonegap"><a href="~/en-us/docs/convert_cordova_phonegap/">Convert a Cordova project to PhoneGap</a></li>
 


### PR DESCRIPTION
Same 3 errors:

Package & Publish
"Get your app approved"
TOC doesn't slide open

Known issues:
second "Nuget Package Manager" should be Plugins Installation

under tutorials and samples 2 links were broken
